### PR TITLE
Perform initialization in __init__

### DIFF
--- a/src/bodies/Bodies.jl
+++ b/src/bodies/Bodies.jl
@@ -38,19 +38,22 @@ const ssb = SolarSystemBarycenter()
 Base.show(io::IO, ::SolarSystemBarycenter) = print(io, "Solar System Barycenter")
 naifid(::SolarSystemBarycenter) = 0
 from_naifid(::Val{0}) = ssb
-add_vertex!(bodies, 0)
 
 struct Sun <: CelestialBody end
 const sun = Sun()
 parent(::Sun) = ssb
 naifid(::Sun) = 10
 from_naifid(::Val{10}) = sun
-add_edge!(bodies, 0, 10)
 
 include("planets.jl")
 include("minor.jl")
 include("satellites.jl")
 
 include(joinpath(@__DIR__, "..", "..", "gen", "gm.jl"))
+
+function __init__()
+    add_vertex!(bodies, 0)
+    add_edge!(bodies, 0, 10)
+end
 
 end


### PR DESCRIPTION
Fixes https://github.com/timholy/Revise.jl/issues/300. I am a little bit surprised that this package even precompiled correctly before this change, though I guess none of the data structures needed rehashing.